### PR TITLE
Additional changes to complete upstream PR #46748

### DIFF
--- a/doc/topics/releases/fluorine.rst
+++ b/doc/topics/releases/fluorine.rst
@@ -24,6 +24,15 @@ The Salt Syndic currently sends an old style  `syndic_start` event as well. The
 syndic respects :conf_minion:`enable_legacy_startup_events` as well.
 
 
+Pass Through Options to :py:func:`file.serialize <salt.states.file.serialize>` State
+------------------------------------------------------------------------------------
+
+This allows for more granular control over the way in which the dataset is
+serialized. See the documentation for the new ``serializer_opts`` option in the
+:py:func:`file.serialize <salt.states.file.serialize>` state for more
+information.
+
+
 Deprecations
 ------------
 

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -21,6 +21,7 @@ from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
     NO_MOCK,
     NO_MOCK_REASON,
+    Mock,
     MagicMock,
     call,
     mock_open,
@@ -83,6 +84,20 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
 
             filestate.serialize('/tmp', dataset, formatter="python")
             self.assertEqual(returner.returned, pprint.pformat(dataset) + '\n')
+
+            mock_serializer = Mock(return_value='')
+            with patch.dict(filestate.__serializers__,
+                            {'json.serialize': mock_serializer}):
+                filestate.serialize(
+                    '/tmp',
+                    dataset,
+                    formatter='json',
+                    serializer_opts=[{'indent': 8}])
+                mock_serializer.assert_called_with(
+                    dataset,
+                    indent=8,
+                    separators=(',', ': '),
+                    sort_keys=True)
 
     def test_contents_and_contents_pillar(self):
         def returner(contents, *args, **kwargs):


### PR DESCRIPTION
- `default_serializer_opts` renamed to `options`. This makes the argument naming more accurate, since the kwargs we pass to the serializer will no longer necessarily be the defaults.
- `repack_dictlist` no longer imported into the global scope. We don't gain any efficiency by doing so, and importing a function into the global scope has 2 side effects: 1) that function's docstring gets processed by the Sphinx autosummary when building the docs, meaning that we'll get docs for `repack_dictlist` in the file state docs, and 2) a `file.repack_dictlist` entry will be added to the dictionary of available states, even though no such state exists.
- additional documentation added to `file.serialize` docstring
- test case added
- release notes added


Refs: https://github.com/saltstack/salt/pull/46748